### PR TITLE
Monitoring: update pod dashboard and node dashbaord to support public…

### DIFF
--- a/cmd/dashboards/nodes/nodes.json
+++ b/cmd/dashboards/nodes/nodes.json
@@ -69,7 +69,7 @@
       ],
       "targets": [
         {
-          "expr": "label_replace(node_uname_info{instance=\"$node:$port\"}, \"node\",  \"$0\", \"nodename\", \".*\") * on(node) group_right kube_node_info",
+          "expr": "label_replace(node_uname_info{instance=\"$node:$port\"}, \"node\",  \"$0\", \"kubernetes_node\", \".*\") * on(node) group_right kube_node_info",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -168,7 +168,7 @@
       ],
       "targets": [
         {
-          "expr": "label_replace(node_uname_info{instance=\"$node:$port\"}, \"node\",  \"$0\", \"nodename\", \".*\") * on(node) group_right sum(kube_node_labels) by (node, label_zone, label_dedicated, label_failure_domain_beta_kubernetes_io_zone, label_beta_kubernetes_io_instance_type)",
+          "expr": "label_replace(node_uname_info{instance=\"$node:$port\"}, \"node\",  \"$0\", \"kubernetes_node\", \".*\") * on(node) group_right sum(kube_node_labels) by (node, label_zone, label_dedicated, label_failure_domain_beta_kubernetes_io_zone, label_beta_kubernetes_io_instance_type)",
           "format": "table",
           "instant": true,
           "intervalFactor": 2,
@@ -233,7 +233,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_bytes_total{ job=\"node-exporter\", instance=\"$node:$port\"}[1m])",
+              "expr": "rate(node_network_receive_bytes_total{ instance=\"$node:$port\"}[2m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ device }}",
@@ -321,7 +321,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_receive_drop_total{ job=\"node-exporter\", instance=\"$node:$port\"}[1m])",
+              "expr": "rate(node_network_receive_drop_total{ instance=\"$node:$port\"}[2m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ device }} - Drop",
@@ -410,7 +410,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_transmit_bytes_total{ job=\"node-exporter\", instance=\"$node:$port\"}[1m])",
+              "expr": "rate(node_network_transmit_bytes_total{ instance=\"$node:$port\"}[2m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{device}}",
@@ -498,7 +498,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(node_network_transmit_drop_total{ job=\"node-exporter\", instance=\"$node:$port\"}[1m])",
+              "expr": "rate(node_network_transmit_drop_total{ instance=\"$node:$port\"}[2m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{device}}",
@@ -602,28 +602,28 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(\n  node_memory_MemTotal_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n  - node_memory_MemFree_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n  - node_memory_Buffers_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n  - node_memory_Cached_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n)\n",
+              "expr": "max(\n  node_memory_MemTotal_bytes{ instance=\"$node:$port\"}\n  - node_memory_MemFree_bytes{ instance=\"$node:$port\"}\n  - node_memory_Buffers_bytes{ instance=\"$node:$port\"}\n  - node_memory_Cached_bytes{ instance=\"$node:$port\"}\n)\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "memory used",
               "refId": "A"
             },
             {
-              "expr": "max(node_memory_Buffers_bytes{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_memory_Buffers_bytes{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "memory buffers",
               "refId": "B"
             },
             {
-              "expr": "max(node_memory_Cached_bytes{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_memory_Cached_bytes{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "memory cached",
               "refId": "C"
             },
             {
-              "expr": "max(node_memory_MemFree_bytes{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_memory_MemFree_bytes{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "memory free",
@@ -732,7 +732,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n    - node_memory_MemFree_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n    - node_memory_Buffers_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n    - node_memory_Cached_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n    )\n    / node_memory_MemTotal_bytes{ job=\"node-exporter\", instance=\"$node:$port\"}\n  ) * 100)\n",
+              "expr": "max(\n  (\n    (\n      node_memory_MemTotal_bytes{ instance=\"$node:$port\"}\n    - node_memory_MemFree_bytes{ instance=\"$node:$port\"}\n    - node_memory_Buffers_bytes{ instance=\"$node:$port\"}\n    - node_memory_Cached_bytes{ instance=\"$node:$port\"}\n    )\n    / node_memory_MemTotal_bytes{ instance=\"$node:$port\"}\n  ) * 100)\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -810,21 +810,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "max(node_load1{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_load1{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "load 1m",
               "refId": "A"
             },
             {
-              "expr": "max(node_load5{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_load5{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "load 5m",
               "refId": "B"
             },
             {
-              "expr": "max(node_load15{ job=\"node-exporter\", instance=\"$node:$port\"})",
+              "expr": "max(node_load15{ instance=\"$node:$port\"})",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "load 15m",
@@ -913,7 +913,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (cpu) (irate(node_cpu_seconds_total{ job=\"node-exporter\", mode!=\"idle\", instance=\"$node:$port\"}[5m]))",
+              "expr": "sum by (cpu) (irate(node_cpu_seconds_total{ mode!=\"idle\", instance=\"$node:$port\"}[5m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{cpu}}",
@@ -1120,7 +1120,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_read_bytes_total{instance=\"$node:$port\"}[1m]) * 512 / rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_read_bytes_total{instance=\"$node:$port\"}[2m]) * 512 / rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1134,7 +1134,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_written_bytes_total{instance=\"$node:$port\"}[1m]) * 512 / rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_written_bytes_total{instance=\"$node:$port\"}[2m]) * 512 / rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1228,14 +1228,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Read: {{device}}",
           "refId": "A"
         },
         {
-          "expr": "rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Write: {{device}}",
@@ -1332,7 +1332,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(node_disk_io_time_seconds_total{ job=\"node-exporter\",  instance=\"$node:$port\"}[2m])",
+          "expr": "rate(node_disk_io_time_seconds_total{  instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{device}} - IO Time",
@@ -1432,7 +1432,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_read_bytes_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_read_bytes_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1446,7 +1446,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_written_bytes_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_written_bytes_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1540,14 +1540,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(node_disk_read_time_seconds_total{instance=\"$node:$port\"}[1m]) / rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_read_time_seconds_total{instance=\"$node:$port\"}[2m]) / rate(node_disk_reads_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{device}} - Read",
           "refId": "A"
         },
         {
-          "expr": "rate(node_disk_write_time_seconds_total{instance=\"$node:$port\"}[1m]) / rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_write_time_seconds_total{instance=\"$node:$port\"}[2m]) / rate(node_disk_writes_completed_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1824,7 +1824,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_reads_merged_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_reads_merged_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1838,7 +1838,7 @@
           "calculatedInterval": "2m",
           "datasourceErrors": {},
           "errors": {},
-          "expr": "rate(node_disk_writes_merged_total{instance=\"$node:$port\"}[1m])",
+          "expr": "rate(node_disk_writes_merged_total{instance=\"$node:$port\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1901,14 +1901,14 @@
       {
         "allValue": null,
         "datasource": "k8s-cluster",
-        "definition": "label_values(node_boot_time_seconds{ job=\"node-exporter\"}, instance)",
+        "definition": "label_values(node_boot_time_seconds, instance)",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "node",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{ job=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds, instance)",
         "refresh": 2,
         "regex": "/(.*):.*/",
         "skipUrlSync": false,
@@ -1933,7 +1933,7 @@
         "multi": false,
         "name": "port",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{ job=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds, instance)",
         "refresh": 2,
         "regex": "/.*:(\\d+)/",
         "skipUrlSync": false,

--- a/cmd/dashboards/pods/pods.json
+++ b/cmd/dashboards/pods/pods.json
@@ -173,21 +173,21 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kubelet_volume_stats_capacity_bytes{job=\"kubelet\", persistentvolumeclaim=\"$pvc\"}",
+              "expr": "kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=\"$pvc\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
               "refId": "A"
             },
             {
-              "expr": "kubelet_volume_stats_used_bytes{job=\"kubelet\", persistentvolumeclaim=\"$pvc\"}",
+              "expr": "kubelet_volume_stats_used_bytes{persistentvolumeclaim=\"$pvc\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Used",
               "refId": "B"
             },
             {
-              "expr": "kubelet_volume_stats_available_bytes{job=\"kubelet\", persistentvolumeclaim=\"$pvc\"}",
+              "expr": "kubelet_volume_stats_available_bytes{persistentvolumeclaim=\"$pvc\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Free",
@@ -443,7 +443,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 29
       },
       "id": 5,
       "links": [],
@@ -466,7 +466,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "/Time|instance|uid|__name__|created_by_kind|created_by_name|job|endpoint|host_ip|namespace|service/",
+          "pattern": "/Time|instance|uid|__name__|created_by_kind|created_by_name|job|endpoint|namespace|service/",
           "thresholds": [],
           "type": "hidden",
           "unit": "short"
@@ -485,7 +485,7 @@
           "linkTargetBlank": false,
           "linkUrl": "/d/fa49a4706d07a042595b664c87fb33ea/nodes-info?orgId=1&var-cluster=&var-node=${__cell}&var-port=$port",
           "mappingType": 1,
-          "pattern": "node_ip",
+          "pattern": "host_ip",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -509,7 +509,7 @@
       ],
       "targets": [
         {
-          "expr": "((label_replace(label_replace(node_uname_info, \"node_ip\", \"$1\", \"instance\", \"(.*):.*\"), \"node\", \"$0\", \"nodename\", \".*\") * on (node) group_right(node_ip) kube_pod_info{namespace=\"$namespace\", pod=\"$pod\"}) * on(namespace, pod) group_left(phase) (kube_pod_status_phase{namespace=\"$namespace\", pod=\"$pod\"} == 1)) * on (namespace, pod) group_left(Value) kube_pod_start_time{namespace=\"$namespace\", pod=\"$pod\"} * 1000",
+          "expr": "(label_replace(node_uname_info, \"host_ip\", \"$1\", \"instance\", \"(.*):.*\")) * on (host_ip) group_right kube_pod_info{namespace=\"$namespace\", pod=\"$pod\"} * on(namespace, pod) group_left(phase) (kube_pod_status_phase{namespace=\"$namespace\", pod=\"$pod\"} == 1) * on (namespace, pod) group_left(Value) kube_pod_start_time{namespace=\"$namespace\", pod=\"$pod\"} * 1000",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -682,21 +682,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", image!=\"\", pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"}[1m]))",
+          "expr": "sum by (container_name) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", image!=\"\", pod_name=\"$pod\", container_name=~\"$container\", container_name!=\"POD\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Current: {{ container_name }}",
           "refId": "A"
         },
         {
-          "expr": "sum by(container) (kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
+          "expr": "sum by(container) (kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Requested: {{ container }}",
           "refId": "B"
         },
         {
-          "expr": "sum by(container) (kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
+          "expr": "sum by(container) (kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\", pod=\"$pod\", container=~\"$container\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Limit: {{ container }}",
@@ -785,14 +785,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
+          "expr": "sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "RX",
           "refId": "A"
         },
         {
-          "expr": "sort_desc(sum by (pod_name) (rate(container_network_transmit_bytes_total{job=\"kubelet\", cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
+          "expr": "sort_desc(sum by (pod_name) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", pod_name=\"$pod\"}[1m])))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "TX",
@@ -1039,14 +1039,14 @@
           "value": "9100"
         },
         "datasource": "k8s-cluster",
-        "definition": "label_values(node_boot_time_seconds{cluster=\"$cluster\", job=\"node-exporter\"}, instance)",
+        "definition": "label_values(node_boot_time_seconds{cluster=\"$cluster\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "port",
         "options": [],
-        "query": "label_values(node_boot_time_seconds{cluster=\"$cluster\", job=\"node-exporter\"}, instance)",
+        "query": "label_values(node_boot_time_seconds{cluster=\"$cluster\"}, instance)",
         "refresh": 2,
         "regex": "/.*:(\\d+)/",
         "skipUrlSync": false,

--- a/k8s-monitor/prometheus.yaml
+++ b/k8s-monitor/prometheus.yaml
@@ -205,6 +205,8 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_app]
         regex: node-exporter
         action: keep
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        target_label: kubernetes_node
 
     - job_name: pod
       kubernetes_sd_configs:


### PR DESCRIPTION
BackGround
Due to different deployment  way of node exporter and kube-state-metrics, we should not add job name in expression.
Some expressions does not support public cloud platform, so we need to fix it.
