### PR TITLE
dm-monitor-initializer building

### DIFF
--- a/cmd/monitoring.go
+++ b/cmd/monitoring.go
@@ -230,7 +230,7 @@ func PushPullRequest() error {
 }
 
 func getTag(defaultTag string) string {
-	if useGlobalTag {
+	if useGlobalTag && defaultTag == "" {
 		return tag
 	}
 

--- a/monitoring.yaml
+++ b/monitoring.yaml
@@ -19,6 +19,12 @@ components:
   - repo_name: "tics"
     monitor_path: "metrics/grafana"
     rule_path: "metrics/alertmanager"
+  - repo_name: "dm"
+    monitor_path: "dm/dm-ansible/scripts"
+    rule_path: "dm/dm-ansible/conf"
+    ref: v2.0.0
+# if the option ref: of repo is not setted in here, the default tag of repo will be setted by CLI --tag flag when running monitoring.
+# if the option ref: of repo is setted in here, the default tag of repo will be this ref: .
 
 platform_monitoring:
     repo_name: "monitoring"

--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -32,6 +32,7 @@ var (
 		"lightning.json":             "Test-Cluster-Lightning",
 		"tiflash_summary.json":       "Test-Cluster-TiFlash-Summary",
 		"tiflash_proxy_summary.json": "Test-Cluster-TiFlash-Proxy-Summary",
+		"dm.json":                    "Test-Cluster-DM",
 	}
 )
 

--- a/platform-monitoring/operator/datasource/dm-cluster-datasource.yaml
+++ b/platform-monitoring/operator/datasource/dm-cluster-datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - access: proxy
+    editable: false
+    name: dm-cluster
+    orgId: 1
+    type: prometheus
+    url: http://127.0.0.1:9090
+    version: 1

--- a/platform-monitoring/operator/init.sh
+++ b/platform-monitoring/operator/init.sh
@@ -41,6 +41,10 @@ sed -i 's/Test-Cluster-TiFlash-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Summary/g'  
 cp /tmp/tiflash_proxy_summary.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiFlash-Proxy-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Proxy-Summary/g' $GF_PROVISIONING_PATH/dashboards/tiflash_proxy_summary.json
 
+# DM
+cp /tmp/dm.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-DM/'$DM_CLUSTER_NAME'-DM/g'  $GF_PROVISIONING_PATH/dashboards/dm.json
+
 # Rules
 if [ ! -d $PROM_CONFIG_PATH/rules  ];then
     mkdir -p $PROM_CONFIG_PATH/rules


### PR DESCRIPTION
# File Change
1. change monitoring.go tag logic, prefers "ref" config in monitoring.yaml rather than global --tag config.
2. update init.sh and monitoring.yaml, add dm config file

# Result
docker image has been pushed to [here](https://hub.pingcap.net/harbor/projects/2/repositories/pingcap%2Fdm-monitor-initializer), grafana, prometheus config file have been bundled in container image.