### PR TITLE
Add TiFlash-Proxy-Details monitor dashboard

### DIFF
--- a/cmd/init.sh
+++ b/cmd/init.sh
@@ -40,6 +40,8 @@ cp /tmp/tiflash_summary.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiFlash-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Summary/g'  $GF_PROVISIONING_PATH/dashboards/tiflash_summary.json
 cp /tmp/tiflash_proxy_summary.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiFlash-Proxy-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Proxy-Summary/g' $GF_PROVISIONING_PATH/dashboards/tiflash_proxy_summary.json
+cp /tmp/tiflash_proxy_details.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-TiFlash-Proxy-Details/'$TIDB_CLUSTER_NAME'-TiFlash-Proxy-Details/g' $GF_PROVISIONING_PATH/dashboards/tiflash_proxy_details.json
 
 # To support monitoring multiple clusters with one TidbMonitor, change the job label to component
 sed -i 's%job=\\\"tiflash\\\"%component=\\"tiflash\\"%g' $GF_PROVISIONING_PATH/dashboards/*.json

--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -32,6 +32,7 @@ var (
 		"lightning.json":             "Test-Cluster-Lightning",
 		"tiflash_summary.json":       "Test-Cluster-TiFlash-Summary",
 		"tiflash_proxy_summary.json": "Test-Cluster-TiFlash-Proxy-Summary",
+		"tiflash_proxy_details.json": "Test-Cluster-TiFlash-Proxy-Details",
 	}
 )
 

--- a/platform-monitoring/operator/init.sh
+++ b/platform-monitoring/operator/init.sh
@@ -40,6 +40,8 @@ cp /tmp/tiflash_summary.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiFlash-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Summary/g'  $GF_PROVISIONING_PATH/dashboards/tiflash_summary.json
 cp /tmp/tiflash_proxy_summary.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiFlash-Proxy-Summary/'$TIDB_CLUSTER_NAME'-TiFlash-Proxy-Summary/g' $GF_PROVISIONING_PATH/dashboards/tiflash_proxy_summary.json
+cp /tmp/tiflash_proxy_details.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-TiFlash-Proxy-Details/'$TIDB_CLUSTER_NAME'-TiFlash-Proxy-Details/g' $GF_PROVISIONING_PATH/dashboards/tiflash_proxy_details.json
 
 # To support monitoring multiple clusters with one TidbMonitor, change the job label to component
 sed -i 's%job=\\\"tiflash\\\"%component=\\"tiflash\\"%g' $GF_PROVISIONING_PATH/dashboards/*.json


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
Add `tiflash_proxy_details.json` to support monitor tiflash proxy details in grafana.
Fix [#3636](https://github.com/pingcap/tidb-operator/issues/3636)

### What is changed and how does it work?
Add tiflash proxy details monitoring configuration.

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [x] Manual test 

    1. Test env perpare

        ```
        kind create cluster
        ./hack/local-up-operator.sh
        kc apply -f examples/basic/tidb-cluster.yaml
        ```

    2. Build test image

        ```shell
        cd cmd/
        go build monitoring.go
        ./monitoring.go --config ../monitoring.yaml --tag v4.0.9
        docker build . xxx
        docker push xxx
        ```

    3. Deploy tidb monitor

        tidb-monitor.yaml

        ```
        apiVersion: pingcap.com/v1alpha1
        kind: TidbMonitor
        metadata:
          name: basic
        spec:
          clusters:
          - name: basic
          prometheus:
            baseImage: prom/prometheus
            version: v2.18.1
          grafana:
            baseImage: grafana/grafana
            version: 6.1.6
          initializer:
            baseImage: hub.pingcap.net/xxx/tiflash-monitor
            version: test
          reloader:
            baseImage: pingcap/tidb-monitor-reloader
            version: v1.0.1
          imagePullPolicy: IfNotPresent
        ```

        ```shell
        kc apply -f tidb-monitor.yaml
        ```

    4. Result

        
![image](https://user-images.githubusercontent.com/17800386/105147753-902d8600-5b3c-11eb-9e65-233206b10c03.png)
![image](https://user-images.githubusercontent.com/17800386/105147831-a9363700-5b3c-11eb-8eb8-11a09a7e0495.png)

