### PR TITLE
Add check for unhealthy stores

### DIFF
--- a/monitor-snapshot/master/operator/rules/pd.rules.yml
+++ b/monitor-snapshot/master/operator/rules/pd.rules.yml
@@ -57,6 +57,20 @@ groups:
         $value }}'
       summary: PD_cluster_lost_connect_tikv_nums
       value: '{{ $value }}'
+  - alert: PD_cluster_unhealthy_tikv_nums
+    expr: (sum ( pd_cluster_status{type="store_unhealth_count"} ) by (instance)
+      > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
+    for: 1m
+    labels:
+      env: ENV_LABELS_ENV
+      expr: (sum ( pd_cluster_status{type="store_unhealth_count"} ) by (instance)
+        > 0) and (sum(etcd_server_is_leader) by (instance) > 0)
+      level: warning
+    annotations:
+      description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values:{{
+        $value }}'
+      summary: PD_cluster_unhealth_tikv_nums
+      value: '{{ $value }}'
   - alert: PD_cluster_low_space
     expr: (sum ( pd_cluster_status{type="store_low_space_count"} ) by (instance) >
       0) and (sum(etcd_server_is_leader) by (instance) > 0)


### PR DESCRIPTION
When the filesystem of a TiKV node of a v5.3.0 cluster becomes read-only (e.g. due to filesystem errors, or simulated with `fsfreeze(8)` it seems to `store_disconneced_count` for 10m and then to `store_unhealth_count` for another 20m before eventually ending up in `store_down_count`.

It looks like there isn't a check for `store_unhealth_count`, so that's what this PR tries to add.