### PR TITLE
update dashboard to add tiproxy

### DIFF
--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -42,6 +42,7 @@ var (
 		"tiflash_proxy_details.json":   "Test-Cluster-TiFlash-Proxy-Details",
 		"DM-Monitor-Standard.json":     "Test-Cluster-DM-Standard",
 		"DM-Monitor-Professional.json": "Test-Cluster-DM-Professional",
+		"tiproxy_summary.json":         "Test-Cluster-TiProxy-Summary",
 	}
 )
 


### PR DESCRIPTION
TiProxy was added to `monitoring.yaml` (https://github.com/pingcap/monitoring/blob/master/monitoring.yaml#L25-L28) but not added to the operator dashboard list.

```
$go run ./cmd/monitoring.go --tag master --config monitoring.yaml
Done.
$ls monitor-snapshot/master/operator/dashboards/tiproxy_summary.json
monitor-snapshot/master/operator/dashboards/tiproxy_summary.json
```