### PR TITLE
fix(cmd): fix monitoring.go

### DIFF
--- a/cmd/monitoring.go
+++ b/cmd/monitoring.go
@@ -2,25 +2,25 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
-	"golang.org/x/oauth2"
-
 	"github.com/google/go-github/github"
-	"github.com/pingcap/monitoring/pkg/ansible"
-	"github.com/pingcap/monitoring/pkg/common"
-	"github.com/pingcap/monitoring/pkg/operator"
-	traceErr "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/youthlin/stream"
 	streamtypes "github.com/youthlin/stream/types"
+	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v2"
+
+	"github.com/pingcap/monitoring/pkg/ansible"
+	"github.com/pingcap/monitoring/pkg/common"
+	"github.com/pingcap/monitoring/pkg/operator"
 )
 
 const (
@@ -77,11 +77,10 @@ func main() {
 		Run: func(co *cobra.Command, args []string) {
 			defer func() {
 				if err := recover(); err != nil {
-					traceE := traceErr.Wrap(err.(error), "")
-					fmt.Printf("%+v", traceE)
-					os.RemoveAll(baseTagDir)
+					traceE := errors.Wrap(err.(error), "")
+					log.Fatalf("%+v", traceE)
 				} else {
-					fmt.Println("Done.")
+					log.Println("Done.")
 				}
 			}()
 			common.CheckErr(stepUp(), "init env failed")


### PR DESCRIPTION
- It should exit with non-zero code when err happened.
- And it's no need to delete the folder otherwise it will delete the normal dir when error happened.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>