### PR TITLE
fix: fix rules parse with prome model and YAML v3

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	goerrors "errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -418,9 +419,9 @@ func exist(path string) bool {
 }
 
 func replaceAlertExpr(content []byte) ([]byte, error) {
-	var groups rulefmt.RuleGroups
-	if err := yaml.UnmarshalStrict(content, &groups); err != nil {
-		return nil, err
+	groups, errs := rulefmt.Parse(content)
+	if len(errs) > 0 {
+		return nil, goerrors.Join(errs...)
 	}
 
 	var newGS rulefmt.RuleGroups

--- a/pkg/operator/rules.go
+++ b/pkg/operator/rules.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -31,9 +32,9 @@ func WriteRule(body string, ruleName string, baseDir string, needToReplaceExpr m
 }
 
 func replaceAlertExpr(content []byte, needToReplaceExpr map[string]string) ([]byte, error) {
-	var groups rulefmt.RuleGroups
-	if err := yaml.UnmarshalStrict(content, &groups); err != nil {
-		return nil, err
+	groups, errs := rulefmt.Parse(content)
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
 	}
 
 	var newGS rulefmt.RuleGroups


### PR DESCRIPTION
fix ```cannot unmarshal !!str `tikv_cd...` into yaml.Node``` (parse content to a YAML v3 node with YAML v2 pkg)