### PR TITLE
ticdc: add the monitor of pingcap/ticdc repo

### DIFF
--- a/monitoring.yaml
+++ b/monitoring.yaml
@@ -19,6 +19,9 @@ components:
   - repo_name: "tiflow"
     monitor_path: "metrics/grafana"
     rule_path: "metrics/alertmanager"
+  - repo_name: "ticdc"
+    monitor_path: "metrics/grafana"
+    # rule_path: "" TODO: This repo is a new arch of ticdc, we will add this rule_path later
   - repo_name: "tiproxy"
     monitor_path: "pkg/metrics/grafana"
     rule_path: "pkg/metrics/alertmanager"


### PR DESCRIPTION
This PR introduces monitoring support for the new architecture of TiCDC (to be released in v8.6) and ensures compatibility with TiUP and TiOperator.