### PR TITLE
build: fix go version in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/monitoring
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
## Why

```console
> go run ./cmd/monitoring.go --tag master --config monitoring.yaml --token <token>
go: updates to go.mod needed; to update it:
	go mod tidy
```