### PR TITLE
build: add non-root user and group in images

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,11 +1,13 @@
 FROM busybox
 
-ADD init.sh /usr/bin/init.sh
-RUN chmod +x /usr/bin/init.sh
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN addgroup -g ${PINGCAP_GID} pingcap && \
+    adduser -u ${PINGCAP_UID} -G pingcap -h /home/pingcap -D pingcap
 
-COPY dashboards/*.json /tmp/
-COPY rules/*.rules.yml /tmp/
-COPY datasources/*.yaml /tmp/
+COPY --chmod=755 init.sh /usr/bin/init.sh
+COPY --chmod=644 dashboards/*.json rules/*.rules.yml datasources/*.yaml /tmp/
 
 ENTRYPOINT ["/usr/bin/init.sh"]
 CMD ["TIDB-Cluster", "/grafana-dashboard-definitions/tidb/", "false", "/etc/prometheus"]

--- a/monitor-snapshot/master/operator/Dockerfile
+++ b/monitor-snapshot/master/operator/Dockerfile
@@ -1,11 +1,13 @@
 FROM busybox:1.37.0
 
-ADD init.sh /usr/bin/init.sh
-RUN chmod +x /usr/bin/init.sh
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN addgroup -g ${PINGCAP_GID} pingcap && \
+    adduser -u ${PINGCAP_UID} -G pingcap -h /home/pingcap -D pingcap
 
-COPY dashboards/*.json /tmp/
-COPY rules/*.rules.yml /tmp/
-COPY datasources/*.yaml /tmp/
+COPY --chmod=755 init.sh /usr/bin/init.sh
+COPY --chmod=644 dashboards/*.json rules/*.rules.yml datasources/*.yaml /tmp/
 
 ENTRYPOINT ["/usr/bin/init.sh"]
 CMD ["TIDB-Cluster", "/grafana-dashboard-definitions/tidb/", "false", "/etc/prometheus"]

--- a/platform-monitoring/operator/Dockerfile
+++ b/platform-monitoring/operator/Dockerfile
@@ -1,11 +1,13 @@
 FROM busybox:1.37.0
 
-ADD init.sh /usr/bin/init.sh
-RUN chmod +x /usr/bin/init.sh
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN addgroup -g ${PINGCAP_GID} pingcap && \
+    adduser -u ${PINGCAP_UID} -G pingcap -h /home/pingcap -D pingcap
 
-COPY dashboards/*.json /tmp/
-COPY rules/*.rules.yml /tmp/
-COPY datasources/*.yaml /tmp/
+COPY --chmod=755 init.sh /usr/bin/init.sh
+COPY --chmod=644 dashboards/*.json rules/*.rules.yml datasources/*.yaml /tmp/
 
 ENTRYPOINT ["/usr/bin/init.sh"]
 CMD ["TIDB-Cluster", "/grafana-dashboard-definitions/tidb/", "false", "/etc/prometheus"]

--- a/reload/Dockerfile
+++ b/reload/Dockerfile
@@ -1,6 +1,11 @@
 FROM busybox:1.37.0
 
-COPY ./build/linux/reload  /bin/reload
-ENTRYPOINT [ "/bin/reload" ]
-CMD        [ "--watch-path=/etc/prometheus/rules", \
-             "--prometheus-url=http://127.0.0.1:9090" ]
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN addgroup -g ${PINGCAP_GID} pingcap && \
+    adduser -u ${PINGCAP_UID} -G pingcap -h /home/pingcap -D pingcap
+
+COPY --chmod=755 ./build/linux/reload  /bin/reload
+ENTRYPOINT ["/bin/reload"]
+CMD        ["--watch-path=/etc/prometheus/rules", "--prometheus-url=http://127.0.0.1:9090"]

--- a/reload/Dockerfile_buildx
+++ b/reload/Dockerfile_buildx
@@ -5,7 +5,14 @@ COPY reload ./reload
 RUN CGO_ENABLED=0 go build -v ./reload/main.go
 
 FROM busybox:1.37.0
-COPY --from=builder /app/main  /bin/reload
+
+# Add user and group to support run it with non-root.
+ARG PINGCAP_UID=1000
+ARG PINGCAP_GID=2000
+RUN addgroup -g ${PINGCAP_GID} pingcap && \
+    adduser -u ${PINGCAP_UID} -G pingcap -h /home/pingcap -D pingcap
+
+COPY --from=builder --chmod=755 /app/main  /bin/reload
 ENTRYPOINT [ "/bin/reload" ]
 CMD        [ "--watch-path=/etc/prometheus/rules", \
              "--prometheus-url=http://127.0.0.1:9090" ]


### PR DESCRIPTION
This pull request updates several Dockerfiles across the project to improve container security and file permission handling. The main changes are the addition of a non-root user and group for running containers, and more explicit control over file permissions during the build process.

**Security and user management improvements:**

* Added creation of a dedicated `pingcap` user and group (with configurable UID/GID) in all relevant Dockerfiles to allow running containers as non-root, enhancing security. [[1]](diffhunk://#diff-c06f05e38e556217d7bdd4d1d715fad986024f661bffda19d750330660f469a5L3-R10) [[2]](diffhunk://#diff-7bc9760470a2de6e3286c4d9b1fd27701c261946fa7583775ede3870981504abL3-R10) [[3]](diffhunk://#diff-059bdc9f80f9a45d9a25234b80a9e43f7d7e7be380114d65ae398b0fad1c69eaL3-R11) [[4]](diffhunk://#diff-0ce01dd279a97717b68d8eb61c9850290843d8a11f06fef9a099a44803b79158L8-R15)

**File permission and copy enhancements:**

* Updated `COPY` instructions to use `--chmod` flags, ensuring correct permissions are set for scripts and configuration files at build time, and replaced `ADD`/`RUN chmod` patterns for improved clarity and reliability. [[1]](diffhunk://#diff-c06f05e38e556217d7bdd4d1d715fad986024f661bffda19d750330660f469a5L3-R10) [[2]](diffhunk://#diff-7bc9760470a2de6e3286c4d9b1fd27701c261946fa7583775ede3870981504abL3-R10) [[3]](diffhunk://#diff-059bdc9f80f9a45d9a25234b80a9e43f7d7e7be380114d65ae398b0fad1c69eaL3-R11) [[4]](diffhunk://#diff-0ce01dd279a97717b68d8eb61c9850290843d8a11f06fef9a099a44803b79158L8-R15)

These changes make the containers more secure by default and simplify permission management in the Docker build process.