### PR TITLE
fix: TiCDC new arch dashboard file is missing

### DIFF
--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -50,7 +49,7 @@ var (
 func WriteDashboard(dir string, body string, name string) error {
 	title, exist := dashboards[name]
 	if !exist {
-		return errors.New(fmt.Sprintf("%s dashboard is not found in operator", name))
+		return fmt.Errorf("%s dashboard is not found in operator", name)
 	}
 
 	common.WriteFile(dir, convertDashboardFileName(name), filterDashboard(body, name, title))

--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -38,6 +38,7 @@ var (
 		"tiflash_proxy_summary.json":   "Test-Cluster-TiFlash-Proxy-Summary",
 		"ticdc.json":                   "Test-Cluster-TiCDC",
 		"TiCDC-Monitor-Summary.json":   "Test-Cluster-TiCDC-Summary",
+		"ticdc_new_arch.json":          "Test-Cluster-TiCDC-New-Arch",
 		"tikv-cdc.json":                "Test-Cluster-TiKV-CDC",
 		"tiflash_proxy_details.json":   "Test-Cluster-TiFlash-Proxy-Details",
 		"DM-Monitor-Standard.json":     "Test-Cluster-DM-Standard",


### PR DESCRIPTION
Only setting in the following two places is not enough:

- https://github.com/pingcap/monitoring/blob/71d0c7b478f0601d26c89556f7f914041b7a792c/monitoring.yaml#L22-L23
- https://github.com/pingcap/monitoring/blob/71d0c7b478f0601d26c89556f7f914041b7a792c/cmd/init.sh#L99-L101