### PR TITLE
Add TiCI dashboards to monitoring operator snapshots

### DIFF
--- a/cmd/init.sh
+++ b/cmd/init.sh
@@ -100,6 +100,14 @@ sed -i 's/Test-Cluster-TiCDC-Summary/'$TIDB_CLUSTER_NAME'-TiCDC/g' $GF_PROVISION
 cp /tmp/ticdc_new_arch.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiCDC-New-Arch/'$TIDB_CLUSTER_NAME'-TiCDC/g' $GF_PROVISIONING_PATH/dashboards/ticdc_new_arch.json
 
+# TiCI dashboard
+cp /tmp/tici_meta.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-TiCI-Meta/Cluster-TiCI-Meta/g' $GF_PROVISIONING_PATH/dashboards/tici_meta.json
+cp /tmp/tici_worker.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-TiCI-Worker/Cluster-TiCI-Worker/g' $GF_PROVISIONING_PATH/dashboards/tici_worker.json
+cp /tmp/tici_reader.json $GF_PROVISIONING_PATH/dashboards
+sed -i 's/Test-Cluster-TiCI-Reader/Cluster-TiCI-Reader/g' $GF_PROVISIONING_PATH/dashboards/tici_reader.json
+
 # TiKV-CDC dashboard
 cp /tmp/tikv-cdc.json $GF_PROVISIONING_PATH/dashboards
 sed -i 's/Test-Cluster-TiKV-CDC/'$TIDB_CLUSTER_NAME'-TiKV-CDC/g' $GF_PROVISIONING_PATH/dashboards/tikv-cdc.json

--- a/monitoring.yaml
+++ b/monitoring.yaml
@@ -22,6 +22,9 @@ components:
   - repo_name: "ticdc"
     monitor_path: "metrics/grafana"
     # rule_path: "" TODO: This repo is a new arch of ticdc, we will add this rule_path later
+  - repo_name: "tici"
+    owner: "pingcap-inc"
+    monitor_path: "grafana"
   - repo_name: "tiproxy"
     monitor_path: "pkg/metrics/grafana"
     rule_path: "pkg/metrics/alertmanager"

--- a/pkg/operator/dashboards.go
+++ b/pkg/operator/dashboards.go
@@ -43,6 +43,9 @@ var (
 		"DM-Monitor-Standard.json":     "Test-Cluster-DM-Standard",
 		"DM-Monitor-Professional.json": "Test-Cluster-DM-Professional",
 		"tiproxy_summary.json":         "Test-Cluster-TiProxy-Summary",
+		"tici_meta.json":               "Test-Cluster-TiCI-Meta",
+		"tici_worker.json":             "Test-Cluster-TiCI-Worker",
+		"tici_reader.json":             "Test-Cluster-TiCI-Reader",
 	}
 )
 


### PR DESCRIPTION
## Summary
This PR integrates TiCI dashboards into the monitoring repo so they are packaged and deployed the same way as other components (PD/TiKV/TiDB/TiCDC/TiFlash).