### PR TITLE
ci: replace deprecated PingCAP domains

### DIFF
--- a/scripts/build_tiup_grafana.sh
+++ b/scripts/build_tiup_grafana.sh
@@ -8,7 +8,7 @@ GrafanaPath=grafana-$TARGET_OS-$TARGET_ARCH
 grafanaFile="grafana-${grafanaVer}.${TARGET_OS}-${TARGET_ARCH}.tar.gz"
 downloadUrl="https://dl.grafana.com/oss/release/$grafanaFile"
 if [ "$TARGET_OS/$TARGET_ARCH" = "darwin/arm64" ]; then
-	downloadUrl="https://download.pingcap.org/$grafanaFile"
+	downloadUrl="https://download.pingcap.com/$grafanaFile"
 fi
 mkdir -p $GrafanaPath && cd "$GrafanaPath"
 mkdir -p grafana


### PR DESCRIPTION
## Summary
- replace deprecated PingCAP download-domain references in monitoring scripts
- keep existing paths and protocols unchanged

## Validation
- `git diff --check`
- verified no remaining old-domain matches in touched files