### PR TITLE
grafana: add max ping latency metric

### DIFF
--- a/platform-monitoring/ansible/grafana/blackbox_exporter.json
+++ b/platform-monitoring/ansible/grafana/blackbox_exporter.json
@@ -112,8 +112,17 @@
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "",
+          "legendFormat": "Ping Latency",
           "refId": "A",
+          "step": 20
+        },
+        {
+          "expr": "max_over_time(probe_duration_seconds{job=\"$PingJobHost\"}[1m])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Max Ping Latency",
+          "refId": "B",
           "step": 20
         }
       ],


### PR DESCRIPTION
close: #1071
## Summary
- keep the existing Ping Latency series for raw probe duration
- add a Max Ping Latency series using max_over_time on probe_duration_seconds over 1 minute for the selected PingJobHost
- align the new series with the BLACKER_ping_latency_more_than_1s alert logic while preserving PingJobHost filtering

## Validation
- git diff --check
- reviewed the updated Grafana panel JSON diff