### PR TITLE
ci(reloader-dockerhub): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/reloader-dockerhub.yaml
+++ b/.github/workflows/reloader-dockerhub.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'reloader/v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.