### PR TITLE
fix(scripts): download prometheus from github releases

### DIFF
--- a/scripts/prepare_prometheus.sh
+++ b/scripts/prepare_prometheus.sh
@@ -39,7 +39,7 @@ main() {
     ## Compose prometheus files from the community repo.
     rm -rf ${archive_dir}/prometheus
     prometheus_dirname="prometheus-${prometheus_ver}.${prometheus_os}-${prometheus_arch}"
-    prometheus_download_url="https://download.pingcap.org/${prometheus_dirname}.tar.gz"
+    prometheus_download_url="https://github.com/prometheus/prometheus/releases/download/v${prometheus_ver}/${prometheus_dirname}.tar.gz"
     wget "$prometheus_download_url" -O - | tar -zxvf - --strip-components=0 -C "$archive_dir" "$prometheus_dirname"
     mv "$archive_dir/${prometheus_dirname}" ${archive_dir}/prometheus
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: `download.pingcap.org` has been decommissioned (public DNS returns NXDOMAIN). As a result the community darwin `release-7.5` build (`pingcap-build-package-darwin`, e.g. pipelinerun `bp-monitoring-release-darwin-amd64-djf4s`) fails at `make output/prometheus`:

```
wget: unable to resolve host address 'download.pingcap.org'
tar: prometheus-2.27.1.darwin-amd64: Not found in archive
make: *** [output/prometheus] Error 1
```

### What changed and how does it work?

Switch `scripts/prepare_prometheus.sh` to download the Prometheus tarball from the official GitHub releases (`github.com/prometheus/prometheus/releases`), matching the URL already used on `master` and `release-8.x` branches. No other logic or pinned versions change (darwin/arm64 still uses 2.28.1).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No need to test

Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Prometheus setup now downloads release archives from the official Prometheus GitHub releases, while preserving the existing extraction and rule-copying behavior.
  - This updates the source used during setup without changing the resulting Prometheus configuration or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->